### PR TITLE
Run action on node20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   - push
   - pull_request
 
+permissions: read-all
+
 jobs:
   hygiene:
     name: Hygiene
@@ -13,8 +15,6 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          token: ${{ secrets.PAT }}
 
       - name: Set-up Node.js LTS
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          token: ${{ secrets.PAT }}
 
       - name: Use latest Packer
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: The version to use
     default: latest
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@vercel/ncc": "0.38.1"
   },
   "devDependencies": {
-    "@tsconfig/node16": "16.1.1",
+    "@tsconfig/node20": "20.1.2",
     "@tsconfig/strictest": "2.0.2",
-    "@types/node": "20.9.4",
+    "@types/node": "20.9.5",
     "@typescript-eslint/eslint-plugin": "6.12.0",
     "@typescript-eslint/parser": "6.12.0",
     "eslint": "8.54.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": [
     "@tsconfig/strictest/tsconfig.json",
-    "@tsconfig/node16/tsconfig.json"
+    "@tsconfig/node20/tsconfig.json"
   ],
   "compilerOptions": {
     "noEmit": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,10 +366,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:16.1.1":
-  version: 16.1.1
-  resolution: "@tsconfig/node16@npm:16.1.1"
-  checksum: 0660087773cd67654a676280f88e77433d54c915994fe4aa47b0d535366edaf9413df69ebc54ba8e271874c59cfa046c961d6a1dea0ed1eaf104ffeb4f78de46
+"@tsconfig/node20@npm:20.1.2":
+  version: 20.1.2
+  resolution: "@tsconfig/node20@npm:20.1.2"
+  checksum: e438fa9b93f0e6ea667affbbd3217692bf3f92db1b3dcbfba1dd141a7dbcd647c19ed87ce76871c723bed398759ec4a5590685f3e669b600c9371f143a19e0c1
   languageName: node
   linkType: hard
 
@@ -387,12 +387,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:20.9.4":
-  version: 20.9.4
-  resolution: "@types/node@npm:20.9.4"
+"@types/node@npm:20.9.5":
+  version: 20.9.5
+  resolution: "@types/node@npm:20.9.5"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: c8b48ace4c7e17715fa901201c98275f8e5268cf5895a8d149777eb0ec6c3ef6c831ff3917e92da5453a5dbe13f230caa50b348a0601b0d50eb9e628010c0364
+  checksum: 54b722195e3292d8b14b9aaac971044bf4f2e6d7263c2942fd088213216443878f47c3df441a0722a228cf823ea64c1a5923b362ea5db41f044b7f30ed140bce
   languageName: node
   linkType: hard
 
@@ -3236,9 +3236,9 @@ __metadata:
     "@actions/github": "npm:6.0.0"
     "@actions/io": "npm:1.1.3"
     "@actions/tool-cache": "npm:2.0.1"
-    "@tsconfig/node16": "npm:16.1.1"
+    "@tsconfig/node20": "npm:20.1.2"
     "@tsconfig/strictest": "npm:2.0.2"
-    "@types/node": "npm:20.9.4"
+    "@types/node": "npm:20.9.5"
     "@typescript-eslint/eslint-plugin": "npm:6.12.0"
     "@typescript-eslint/parser": "npm:6.12.0"
     "@vercel/ncc": "npm:0.38.1"


### PR DESCRIPTION
node16 will be deprecated in the future, node20 is supported as the new runtime. Basically the same as #296.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/