### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-06-13
+
+### Changed
+
+- Update default runtime to node24.
+
 ## [3.0.0] - 2023-11-24
 
 ### Changed
@@ -25,7 +31,9 @@ and this project adheres to
 - Initial release
 
 [unreleased]:
-  https://github.com/hashicorp-contrib/setup-packer/compare/v3.0.0...HEAD
+  https://github.com/hashicorp-contrib/setup-packer/compare/v4.0.0...HEAD
+[4.0.0]:
+  https://github.com/hashicorp-contrib/setup-packer/compare/v3.0.0...v4.0.0
 [3.0.0]:
   https://github.com/hashicorp-contrib/setup-packer/compare/v2.0.0...v3.0.0
 [2.0.0]:

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use latest Packer
-        uses: hashicorp-contrib/setup-packer@v3
+        uses: hashicorp-contrib/setup-packer@v4
 
       # or
 
       - name: Use latest Packer
-        uses: hashicorp-contrib/setup-packer@v3
+        uses: hashicorp-contrib/setup-packer@v4
         with:
           packer-version: 1.6.5
 
@@ -53,23 +53,23 @@ specify the version of the action _itself_.
 
 ```yml
 - name: Use latest Packer
-  uses: hashicorp-contrib/setup-packer@v3
+  uses: hashicorp-contrib/setup-packer@v4
   #                                   ^^^
 ```
 
 We recommend that you include the version of the action. We adhere to
 [semantic versioning](https://semver.org), it's safe to use the major version
-(`v2`) in your workflow. If you use the master branch, this could break your
+(`v4`) in your workflow. If you use the master branch, this could break your
 workflow when we publish a breaking update and increase the major version.
 
 ```yml
 steps:
   # Reference the major version of a release (most recommended)
-  - uses: hashicorp-contrib/setup-packer@v3
+  - uses: hashicorp-contrib/setup-packer@v4
   # Reference a specific commit (most strict)
   - uses: hashicorp-contrib/setup-packer@792b061
   # Reference a semver version of a release (not recommended)
-  - uses: hashicorp-contrib/setup-packer@v3.0.0
+  - uses: hashicorp-contrib/setup-packer@v4.0.0
   # Reference a branch (most dangerous)
   - uses: hashicorp-contrib/setup-packer@master
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-packer",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "private": true,
   "license": "ISC",
   "author": "Sora Morimoto <sora@morimoto.io>",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,9 @@ function Release() {
 
   echo "Push tags"
   git push --tags
+
+  echo "Create a GitHub release: $FULL_VERSION"
+  gh release create "$FULL_VERSION" --generate-notes
 }
 
 Release "$1" "$2"


### PR DESCRIPTION
## Summary

- Major release (v4.0.0 / v4) that updates the default runtime to node24
- Bump `package.json` version to 4.0.0
- Add the 4.0.0 entry and comparison links to `CHANGELOG.md`
- Update usage examples and version references in `README.md` to the v4 line
- Add a `gh release create --generate-notes` step to `scripts/release.sh`, modeled after [ocaml/setup-ocaml's release.sh](https://github.com/ocaml/setup-ocaml/blob/master/scripts/release.sh)

## Release steps

After merging, run the following on `master` to create the tags and the GitHub release:

```sh
bash scripts/release.sh v4 v4.0.0
```